### PR TITLE
Load Lodash library using _.noConflict

### DIFF
--- a/lib/enhance.js
+++ b/lib/enhance.js
@@ -3,6 +3,7 @@
   var Enhance, _;
 
   _ = require('./lodash-ext');
+  var lodashExt = _.noConflict();
 
   Enhance = (function() {
     return function(options) {
@@ -14,7 +15,7 @@
         tabletBreakpoint: 1024,
         tabletAsMobile: false
       };
-      options = _.merge(defaults, options);
+      options = lodashExt.merge(defaults, options);
       isHiDPI = function(ratio) {
         var query;
         if (ratio == null) {
@@ -36,13 +37,13 @@
         return typeof window.matchMedia === "function" ? window.matchMedia("only screen and (max-width: " + breakpoint + "px)").matches : void 0;
       };
       helpers = {
-        _: _,
+        _: lodashExt,
         isHiDPI: isHiDPI
       };
       render = function(src, opts) {
         var regexp;
         if (options.render != null) {
-          return typeof options.render === "function" ? options.render(_.merge({
+          return typeof options.render === "function" ? options.render(lodashExt.merge({
             src: src
           }, options, opts, helpers)) : void 0;
         } else {
@@ -50,7 +51,7 @@
           if (isHiDPI()) {
             src = src.replace(regexp, "" + options.suffix + "$1");
           }
-          return _.joinURIComponents(options.host, src);
+          return lodashExt.joinURIComponents(options.host, src);
         }
       };
       return exports = {

--- a/lib/lodash-ext.js
+++ b/lib/lodash-ext.js
@@ -3,17 +3,18 @@
   var _;
 
   _ = require('../vendor/lodash/lodash');
+  var lodash = _.noConflict();
 
-  _.mixin({
+  lodash.mixin({
     joinURIComponents: function() {
       var components, leadingSlashes, uri, _ref;
       leadingSlashes = ((_ref = arguments[0]) != null ? _ref.match(/^[\/]{1,2}/) : void 0) || '';
-      components = _.map(arguments, function(str, i) {
+      components = lodash.map(arguments, function(str, i) {
         if (str != null) {
-          return _.trim(str, '/').split(/\/(?!\/)/);
+          return lodash.trim(str, '/').split(/\/(?!\/)/);
         }
       });
-      return uri = leadingSlashes + _.flatten(_.compact(components)).join('/');
+      return uri = leadingSlashes + lodash.flatten(lodash.compact(components)).join('/');
     },
     trim: function(string, characters) {
       var regexp;
@@ -25,6 +26,6 @@
     }
   });
 
-  module.exports = _;
+  module.exports = lodash;
 
 }).call(this);


### PR DESCRIPTION
[Related to lodash errors in Sentry]

For Enhance, lodash is just manually downloaded. @armyofgnomes and I think there's a race/timing issue sometimes where this _ loads instead. So in this pull I'm using lodash's noconflict method and not touching the global namespace.